### PR TITLE
Support Both Sync & Async functions instead of just removing sync

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -1,12 +1,27 @@
 import 'package:lzstring/lzstring.dart';
 
-void main() async { 
-  String input = "Dart implemntation of lz-string";
-  print('Input: $input');
-  print('Compressed String: ${await LZString.compress(input)}');
-  print('Compressed Base 64 String: ${await LZString.compressToBase64(input)}');
-  print('Compressed UTF16 String: ${await LZString.compressToUTF16(input)}');
+void main() async {
+  String input = "Dart implemntation of lz-string (async)";
+  print('[async] Input: $input');
+  print('[async] Compressed String: ${await LZString.compress(input)}');
   print(
-      'Compressed Encoded URI Component: ${await LZString.compressToEncodedURIComponent(input)}');
-  print('Compressed Uint8 Array: ${await LZString.compressToUint8Array(input)}');
+      '[async] Compressed Base 64 String: ${await LZString.compressToBase64(input)}');
+  print(
+      '[async] Compressed UTF16 String: ${await LZString.compressToUTF16(input)}');
+  print(
+      '[async] Compressed Encoded URI Component: ${await LZString.compressToEncodedURIComponent(input)}');
+  print(
+      '[async] Compressed Uint8 Array: ${await LZString.compressToUint8Array(input)}');
+
+  input = "Dart implemntation of lz-string (sync)";
+  print('[sync] Input: $input');
+  print('[sync] Compressed String: ${await LZString.compressSync(input)}');
+  print(
+      '[sync] Compressed Base 64 String: ${await LZString.compressToBase64Sync(input)}');
+  print(
+      '[sync] Compressed UTF16 String: ${await LZString.compressToUTF16Sync(input)}');
+  print(
+      '[sync] Compressed Encoded URI Component: ${await LZString.compressToEncodedURIComponentSync(input)}');
+  print(
+      '[sync] Compressed Uint8 Array: ${await LZString.compressToUint8ArraySync(input)}');
 }

--- a/lib/lzstring.dart
+++ b/lib/lzstring.dart
@@ -33,9 +33,9 @@ class LZString {
   /// Can be decompressed with `decompressFromBase64`.
   ///
   /// This works by using only 6bits of storage per character. The strings produced are therefore 166% bigger than those produced by `compress`.
-  static Future<String> compressToBase64(String input) async {
+  static String compressToBase64Sync(String input) {
     if (input == null) return "";
-    String res = await _compress(input, 6, (a) => _keyStrBase64[a]);
+    String res = _compressSync(input, 6, (a) => _keyStrBase64[a]);
     switch (res.length % 4) {
       case 0:
         return res;
@@ -49,12 +49,33 @@ class LZString {
     return null;
   }
 
+  /// Produces ASCII UTF-16 strings representing the original string encoded in Base64 from [input].
+  /// Can be decompressed with `decompressFromBase64`.
+  ///
+  /// This works by using only 6bits of storage per character. The strings produced are therefore 166% bigger than those produced by `compress`.
+  static Future<String> compressToBase64(String input) async =>
+      compressToBase64Sync(input);
+
   /// Decompress base64 [input] which produces by `compressToBase64`.
-  static Future<String> decompressFromBase64(String input) async {
+  static String decompressFromBase64Sync(String input) {
     if (input == null) return "";
     if (input == "") return null;
-    return await _decompress(input.length, 32,
+    return _decompressSync(input.length, 32,
         (index) => _getBaseValue(_keyStrBase64, input[index]));
+  }
+
+  /// Decompress base64 [input] which produces by `compressToBase64`.
+  static Future<String> decompressFromBase64(String input) async =>
+      decompressFromBase64Sync(input);
+
+  /// Produces "valid" UTF-16 strings from [input].
+  ///
+  /// Can be decompressed with `decompressFromUTF16`.
+  ///
+  /// This works by using only 15 bits of storage per character. The strings produced are therefore 6.66% bigger than those produced by `compress`.
+  static String compressToUTF16Sync(String input) {
+    if (input == null) return "";
+    return _compressSync(input, 15, (a) => String.fromCharCode(a + 32)) + " ";
   }
 
   /// Produces "valid" UTF-16 strings from [input].
@@ -62,37 +83,44 @@ class LZString {
   /// Can be decompressed with `decompressFromUTF16`.
   ///
   /// This works by using only 15 bits of storage per character. The strings produced are therefore 6.66% bigger than those produced by `compress`.
-  static Future<String> compressToUTF16(String input) async {
-    if (input == null) return "";
-    return await _compress(input, 15, (a) => String.fromCharCode(a + 32)) + " ";
+  static Future<String> compressToUTF16(String input) async =>
+      compressToUTF16Sync(input);
+
+  /// Decompress "valid" UTF-16 string which produces by `compressToUTF16`
+  static String decompressFromUTF16Sync(String compressed) {
+    if (compressed == null) return "";
+    if (compressed == "") return null;
+    return _decompressSync(
+        compressed.length, 16384, (index) => compressed.codeUnitAt(index) - 32);
   }
 
   /// Decompress "valid" UTF-16 string which produces by `compressToUTF16`
-  static Future<String> decompressFromUTF16(String compressed) async {
-    if (compressed == null) return "";
-    if (compressed == "") return null;
-    return await _decompress(
-        compressed.length, 16384, (index) => compressed.codeUnitAt(index) - 32);
+  static Future<String> decompressFromUTF16(String compressed) async =>
+      decompressFromUTF16Sync(compressed);
+
+  /// Produces an uint8Array.
+  ///
+  /// Can be decompressed with `decompressFromUint8Array`
+  static Uint8List compressToUint8ArraySync(String uncompressed) {
+    String compressed = compressSync(uncompressed);
+
+    Uint8List buf = Uint8List(compressed.length * 2);
+    for (var i = 0, totalLen = compressed.length; i < totalLen; i++) {
+      int currentValue = compressed.codeUnitAt(i);
+      buf[i * 2] = currentValue >> 8;
+      buf[i * 2 + 1] = currentValue % 256;
+    }
+    return buf;
   }
 
   /// Produces an uint8Array.
   ///
   /// Can be decompressed with `decompressFromUint8Array`
-  static Future<Uint8List> compressToUint8Array(String uncompressed) async {
-    String compressed = await compress(uncompressed);
-    return Future<Uint8List>(() {
-      Uint8List buf = Uint8List(compressed.length * 2);
-      for (var i = 0, totalLen = compressed.length; i < totalLen; i++) {
-        int currentValue = compressed.codeUnitAt(i);
-        buf[i * 2] = currentValue >> 8;
-        buf[i * 2 + 1] = currentValue % 256;
-      }
-      return buf;
-    });
-  }
+  static Future<Uint8List> compressToUint8Array(String uncompressed) async =>
+      compressToUint8ArraySync(uncompressed);
 
   /// Decompress uint8Array which produces by `compressToUint8Array`.
-  static Future<String> decompressFromUint8Array(Uint8List compressed) async {
+  static String decompressFromUint8ArraySync(Uint8List compressed) {
     if (compressed == null) {
       return "";
     } else {
@@ -102,148 +130,89 @@ class LZString {
       }
       List<String> result = List<String>();
       buf.forEach((c) => result.add(String.fromCharCode(c)));
-      return await decompress(result.join(''));
+      return decompressSync(result.join(''));
     }
   }
 
+  /// Decompress uint8Array which produces by `compressToUint8Array`.
+  static Future<String> decompressFromUint8Array(Uint8List compressed) async =>
+      decompressFromUint8ArraySync(compressed);
+
   /// Decompress ASCII strings [input] which produces by `compressToEncodedURIComponent`.
-  static Future<String> decompressFromEncodedURIComponent(String input) async {
+  static String decompressFromEncodedURIComponentSync(String input) {
     if (input == null) return "";
     if (input == "") return null;
     input = input.replaceAll(' ', '+');
-    return await _decompress(input.length, 32,
+    return _decompressSync(input.length, 32,
         (index) => _getBaseValue(_keyStrUriSafe, input[index]));
+  }
+
+  /// Decompress ASCII strings [input] which produces by `compressToEncodedURIComponent`.
+  static Future<String> decompressFromEncodedURIComponent(String input) async =>
+      decompressFromEncodedURIComponentSync(input);
+
+  /// Produces ASCII strings representing the original string encoded in Base64 with a few tweaks to make these URI safe.
+  ///
+  /// Can be decompressed with `decompressFromEncodedURIComponent`
+  static String compressToEncodedURIComponentSync(String input) {
+    if (input == null) "";
+    return _compressSync(input, 6, (a) => _keyStrUriSafe[a]);
   }
 
   /// Produces ASCII strings representing the original string encoded in Base64 with a few tweaks to make these URI safe.
   ///
   /// Can be decompressed with `decompressFromEncodedURIComponent`
-  static Future<String> compressToEncodedURIComponent(String input) async {
-    if (input == null) "";
-    return await _compress(input, 6, (a) => _keyStrUriSafe[a]);
-  }
+  static Future<String> compressToEncodedURIComponent(String input) async =>
+      compressToEncodedURIComponentSync(input);
 
   /// Produces invalid UTF-16 strings from [uncompressed].
   ///
   /// Can be decompressed with `decompress`.
   ///
-  static Future<String> compress(final String uncompressed) async {
-    return await _compress(uncompressed, 16, (a) => String.fromCharCode(a));
+  static Future<String> compress(final String uncompressed) async =>
+      compressSync(uncompressed);
+
+  /// Produces invalid UTF-16 strings from [uncompressed].
+  ///
+  /// Can be decompressed with `decompress`.
+  ///
+  static String compressSync(final String uncompressed) =>
+      _compressSync(uncompressed, 16, (a) => String.fromCharCode(a));
+
+  static Future<String> _compress(String uncompressed, int bitsPerChar,
+      GetCharFromInt getCharFromInt) async {
+    return _compressSync(uncompressed, bitsPerChar, getCharFromInt);
   }
 
-  static Future<String> _compress(
+  static String _compressSync(
       String uncompressed, int bitsPerChar, GetCharFromInt getCharFromInt) {
-    return Future<String>(() {
-      if (uncompressed == null) return "";
-      int i, value;
-      Map<String, int> contextDictionary = Map<String, int>();
-      Map<String, bool> contextDictionaryToCreate = Map<String, bool>();
-      String contextC = "";
-      String contextWC = "";
-      String contextW = "";
-      int contextEnlargeIn =
-          2; // Compensate for the first entry which should not count
-      int contextDictSize = 3;
-      int contextNumBits = 2;
-      StringBuffer contextData = StringBuffer();
-      int contextDataVal = 0;
-      int contextDataPosition = 0;
-      int ii;
+    if (uncompressed == null) return "";
+    int i, value;
+    Map<String, int> contextDictionary = Map<String, int>();
+    Map<String, bool> contextDictionaryToCreate = Map<String, bool>();
+    String contextC = "";
+    String contextWC = "";
+    String contextW = "";
+    int contextEnlargeIn =
+        2; // Compensate for the first entry which should not count
+    int contextDictSize = 3;
+    int contextNumBits = 2;
+    StringBuffer contextData = StringBuffer();
+    int contextDataVal = 0;
+    int contextDataPosition = 0;
+    int ii;
 
-      for (ii = 0; ii < uncompressed.length; ii++) {
-        contextC = uncompressed[ii];
-        if (!contextDictionary.containsKey(contextC)) {
-          contextDictionary[contextC] = contextDictSize++;
-          contextDictionaryToCreate[contextC] = true;
-        }
-
-        contextWC = contextW + contextC;
-        if (contextDictionary.containsKey(contextWC)) {
-          contextW = contextWC;
-        } else {
-          if (contextDictionaryToCreate.containsKey(contextW)) {
-            if (contextW.codeUnitAt(0) < 256) {
-              for (i = 0; i < contextNumBits; i++) {
-                contextDataVal = (contextDataVal << 1);
-                if (contextDataPosition == bitsPerChar - 1) {
-                  contextDataPosition = 0;
-                  contextData.write(getCharFromInt(contextDataVal));
-                  contextDataVal = 0;
-                } else {
-                  contextDataPosition++;
-                }
-              }
-              value = contextW.codeUnitAt(0);
-              for (i = 0; i < 8; i++) {
-                contextDataVal = (contextDataVal << 1) | (value & 1);
-                if (contextDataPosition == bitsPerChar - 1) {
-                  contextDataPosition = 0;
-                  contextData.write(getCharFromInt(contextDataVal));
-                  contextDataVal = 0;
-                } else {
-                  contextDataPosition++;
-                }
-                value = value >> 1;
-              }
-            } else {
-              value = 1;
-              for (i = 0; i < contextNumBits; i++) {
-                contextDataVal = (contextDataVal << 1) | value;
-                if (contextDataPosition == bitsPerChar - 1) {
-                  contextDataPosition = 0;
-                  contextData.write(getCharFromInt(contextDataVal));
-                  contextDataVal = 0;
-                } else {
-                  contextDataPosition++;
-                }
-                value = 0;
-              }
-              value = contextW.codeUnitAt(0);
-              for (i = 0; i < 16; i++) {
-                contextDataVal = (contextDataVal << 1) | (value & 1);
-                if (contextDataPosition == bitsPerChar - 1) {
-                  contextDataPosition = 0;
-                  contextData.write(getCharFromInt(contextDataVal));
-                  contextDataVal = 0;
-                } else {
-                  contextDataPosition++;
-                }
-                value = value >> 1;
-              }
-            }
-            contextEnlargeIn--;
-            if (contextEnlargeIn == 0) {
-              contextEnlargeIn = pow(2, contextNumBits);
-              contextNumBits++;
-            }
-            contextDictionaryToCreate.remove(contextW);
-          } else {
-            value = contextDictionary[contextW];
-            for (i = 0; i < contextNumBits; i++) {
-              contextDataVal = (contextDataVal << 1) | (value & 1);
-              if (contextDataPosition == bitsPerChar - 1) {
-                contextDataPosition = 0;
-                contextData.write(getCharFromInt(contextDataVal));
-                contextDataVal = 0;
-              } else {
-                contextDataPosition++;
-              }
-              value = value >> 1;
-            }
-          }
-          contextEnlargeIn--;
-          if (contextEnlargeIn == 0) {
-            contextEnlargeIn = pow(2, contextNumBits);
-            contextNumBits++;
-          }
-          // Add wc to the dictionary.
-          contextDictionary[contextWC] = contextDictSize++;
-          contextW = contextC;
-        }
+    for (ii = 0; ii < uncompressed.length; ii++) {
+      contextC = uncompressed[ii];
+      if (!contextDictionary.containsKey(contextC)) {
+        contextDictionary[contextC] = contextDictSize++;
+        contextDictionaryToCreate[contextC] = true;
       }
 
-      // Output the code for w.
-      if (contextW != "") {
+      contextWC = contextW + contextC;
+      if (contextDictionary.containsKey(contextWC)) {
+        contextW = contextWC;
+      } else {
         if (contextDictionaryToCreate.containsKey(contextW)) {
           if (contextW.codeUnitAt(0) < 256) {
             for (i = 0; i < contextNumBits; i++) {
@@ -319,66 +288,211 @@ class LZString {
           contextEnlargeIn = pow(2, contextNumBits);
           contextNumBits++;
         }
+        // Add wc to the dictionary.
+        contextDictionary[contextWC] = contextDictSize++;
+        contextW = contextC;
       }
+    }
 
-      // Mark the end of the stream
-      value = 2;
-      for (i = 0; i < contextNumBits; i++) {
-        contextDataVal = (contextDataVal << 1) | (value & 1);
-        if (contextDataPosition == bitsPerChar - 1) {
-          contextDataPosition = 0;
-          contextData.write(getCharFromInt(contextDataVal));
-          contextDataVal = 0;
+    // Output the code for w.
+    if (contextW != "") {
+      if (contextDictionaryToCreate.containsKey(contextW)) {
+        if (contextW.codeUnitAt(0) < 256) {
+          for (i = 0; i < contextNumBits; i++) {
+            contextDataVal = (contextDataVal << 1);
+            if (contextDataPosition == bitsPerChar - 1) {
+              contextDataPosition = 0;
+              contextData.write(getCharFromInt(contextDataVal));
+              contextDataVal = 0;
+            } else {
+              contextDataPosition++;
+            }
+          }
+          value = contextW.codeUnitAt(0);
+          for (i = 0; i < 8; i++) {
+            contextDataVal = (contextDataVal << 1) | (value & 1);
+            if (contextDataPosition == bitsPerChar - 1) {
+              contextDataPosition = 0;
+              contextData.write(getCharFromInt(contextDataVal));
+              contextDataVal = 0;
+            } else {
+              contextDataPosition++;
+            }
+            value = value >> 1;
+          }
         } else {
-          contextDataPosition++;
+          value = 1;
+          for (i = 0; i < contextNumBits; i++) {
+            contextDataVal = (contextDataVal << 1) | value;
+            if (contextDataPosition == bitsPerChar - 1) {
+              contextDataPosition = 0;
+              contextData.write(getCharFromInt(contextDataVal));
+              contextDataVal = 0;
+            } else {
+              contextDataPosition++;
+            }
+            value = 0;
+          }
+          value = contextW.codeUnitAt(0);
+          for (i = 0; i < 16; i++) {
+            contextDataVal = (contextDataVal << 1) | (value & 1);
+            if (contextDataPosition == bitsPerChar - 1) {
+              contextDataPosition = 0;
+              contextData.write(getCharFromInt(contextDataVal));
+              contextDataVal = 0;
+            } else {
+              contextDataPosition++;
+            }
+            value = value >> 1;
+          }
         }
-        value = value >> 1;
+        contextEnlargeIn--;
+        if (contextEnlargeIn == 0) {
+          contextEnlargeIn = pow(2, contextNumBits);
+          contextNumBits++;
+        }
+        contextDictionaryToCreate.remove(contextW);
+      } else {
+        value = contextDictionary[contextW];
+        for (i = 0; i < contextNumBits; i++) {
+          contextDataVal = (contextDataVal << 1) | (value & 1);
+          if (contextDataPosition == bitsPerChar - 1) {
+            contextDataPosition = 0;
+            contextData.write(getCharFromInt(contextDataVal));
+            contextDataVal = 0;
+          } else {
+            contextDataPosition++;
+          }
+          value = value >> 1;
+        }
       }
+      contextEnlargeIn--;
+      if (contextEnlargeIn == 0) {
+        contextEnlargeIn = pow(2, contextNumBits);
+        contextNumBits++;
+      }
+    }
 
-      // Flush the last char
-      while (true) {
-        contextDataVal = (contextDataVal << 1);
-        if (contextDataPosition == bitsPerChar - 1) {
-          contextData.write(getCharFromInt(contextDataVal));
-          break;
-        } else {
-          contextDataPosition++;
-        }
+    // Mark the end of the stream
+    value = 2;
+    for (i = 0; i < contextNumBits; i++) {
+      contextDataVal = (contextDataVal << 1) | (value & 1);
+      if (contextDataPosition == bitsPerChar - 1) {
+        contextDataPosition = 0;
+        contextData.write(getCharFromInt(contextDataVal));
+        contextDataVal = 0;
+      } else {
+        contextDataPosition++;
       }
-      return contextData.toString();
-    });
+      value = value >> 1;
+    }
+
+    // Flush the last char
+    while (true) {
+      contextDataVal = (contextDataVal << 1);
+      if (contextDataPosition == bitsPerChar - 1) {
+        contextData.write(getCharFromInt(contextDataVal));
+        break;
+      } else {
+        contextDataPosition++;
+      }
+    }
+    return contextData.toString();
   }
 
   /// Decompress invalid UTF-16 strings which produces by `compress`.
-  static Future<String> decompress(final String compressed) async {
+  static Future<String> decompress(final String compressed) async =>
+      decompressSync(compressed);
+
+  /// Decompress invalid UTF-16 strings which produces by `compress`.
+  static String decompressSync(final String compressed) {
     if (compressed == null) return "";
     if (compressed.isEmpty) return null;
-    return await _decompress(
+    return _decompressSync(
         compressed.length, 32768, (index) => compressed.codeUnitAt(index));
   }
 
   static Future<String> _decompress(
+          int length, int resetValue, GetNextValue getNextValue) async =>
+      _decompressSync(length, resetValue, getNextValue);
+
+  static String _decompressSync(
       int length, int resetValue, GetNextValue getNextValue) {
-    return Future<String>(() {
-      Map<int, String> dictionary = Map<int, String>();
-      int enLargeIn = 4,
-          dictSize = 4,
-          numBits = 3,
-          i,
-          bits,
-          maxpower,
-          power,
-          resb;
-      String entry = "", c, w;
-      StringBuffer result = StringBuffer();
-      _Data data = _Data(getNextValue(0), resetValue, 1);
+    Map<int, String> dictionary = Map<int, String>();
+    int enLargeIn = 4,
+        dictSize = 4,
+        numBits = 3,
+        i,
+        bits,
+        maxpower,
+        power,
+        resb;
+    String entry = "", c, w;
+    StringBuffer result = StringBuffer();
+    _Data data = _Data(getNextValue(0), resetValue, 1);
 
-      for (i = 0; i < 3; i++) {
-        dictionary[i] = i.toString();
+    for (i = 0; i < 3; i++) {
+      dictionary[i] = i.toString();
+    }
+
+    bits = 0;
+    maxpower = pow(2, 2);
+    power = 1;
+    while (power != maxpower) {
+      resb = data.value & data.position;
+      data.position >>= 1;
+      if (data.position == 0) {
+        data.position = resetValue;
+        data.value = getNextValue(data.index++);
       }
+      bits |= (resb > 0 ? 1 : 0) * power;
+      power <<= 1;
+    }
 
+    int next = bits;
+    switch (next) {
+      case 0:
+        bits = 0;
+        maxpower = pow(2, 8);
+        power = 1;
+        while (power != maxpower) {
+          resb = data.value & data.position;
+          data.position >>= 1;
+          if (data.position == 0) {
+            data.position = resetValue;
+            data.value = getNextValue(data.index++);
+          }
+          bits |= (resb > 0 ? 1 : 0) * power;
+          power <<= 1;
+        }
+        c = String.fromCharCode(bits);
+        break;
+      case 1:
+        bits = 0;
+        maxpower = pow(2, 16);
+        power = 1;
+        while (power != maxpower) {
+          resb = data.value & data.position;
+          data.position >>= 1;
+          if (data.position == 0) {
+            data.position = resetValue;
+            data.value = getNextValue(data.index++);
+          }
+          bits |= (resb > 0 ? 1 : 0) * power;
+          power <<= 1;
+        }
+        c = String.fromCharCode(bits);
+        break;
+      case 2:
+        return "";
+    }
+    dictionary[3] = c;
+    w = c;
+    result.write(c);
+    while (true) {
+      if (data.index > length) return "";
       bits = 0;
-      maxpower = pow(2, 2);
+      maxpower = pow(2, numBits);
       power = 1;
       while (power != maxpower) {
         resb = data.value & data.position;
@@ -391,8 +505,8 @@ class LZString {
         power <<= 1;
       }
 
-      int next = bits;
-      switch (next) {
+      int cc;
+      switch (cc = bits) {
         case 0:
           bits = 0;
           maxpower = pow(2, 8);
@@ -407,7 +521,9 @@ class LZString {
             bits |= (resb > 0 ? 1 : 0) * power;
             power <<= 1;
           }
-          c = String.fromCharCode(bits);
+          dictionary[dictSize++] = String.fromCharCode(bits);
+          cc = dictSize - 1;
+          enLargeIn--;
           break;
         case 1:
           bits = 0;
@@ -423,99 +539,40 @@ class LZString {
             bits |= (resb > 0 ? 1 : 0) * power;
             power <<= 1;
           }
-          c = String.fromCharCode(bits);
+          dictionary[dictSize++] = String.fromCharCode(bits);
+          cc = dictSize - 1;
+          enLargeIn--;
           break;
         case 2:
-          return "";
+          return result.toString();
       }
-      dictionary[3] = c;
-      w = c;
-      result.write(c);
-      while (true) {
-        if (data.index > length) return "";
-        bits = 0;
-        maxpower = pow(2, numBits);
-        power = 1;
-        while (power != maxpower) {
-          resb = data.value & data.position;
-          data.position >>= 1;
-          if (data.position == 0) {
-            data.position = resetValue;
-            data.value = getNextValue(data.index++);
-          }
-          bits |= (resb > 0 ? 1 : 0) * power;
-          power <<= 1;
-        }
 
-        int cc;
-        switch (cc = bits) {
-          case 0:
-            bits = 0;
-            maxpower = pow(2, 8);
-            power = 1;
-            while (power != maxpower) {
-              resb = data.value & data.position;
-              data.position >>= 1;
-              if (data.position == 0) {
-                data.position = resetValue;
-                data.value = getNextValue(data.index++);
-              }
-              bits |= (resb > 0 ? 1 : 0) * power;
-              power <<= 1;
-            }
-            dictionary[dictSize++] = String.fromCharCode(bits);
-            cc = dictSize - 1;
-            enLargeIn--;
-            break;
-          case 1:
-            bits = 0;
-            maxpower = pow(2, 16);
-            power = 1;
-            while (power != maxpower) {
-              resb = data.value & data.position;
-              data.position >>= 1;
-              if (data.position == 0) {
-                data.position = resetValue;
-                data.value = getNextValue(data.index++);
-              }
-              bits |= (resb > 0 ? 1 : 0) * power;
-              power <<= 1;
-            }
-            dictionary[dictSize++] = String.fromCharCode(bits);
-            cc = dictSize - 1;
-            enLargeIn--;
-            break;
-          case 2:
-            return result.toString();
-        }
+      if (enLargeIn == 0) {
+        enLargeIn = pow(2, numBits);
+        numBits++;
+      }
 
-        if (enLargeIn == 0) {
-          enLargeIn = pow(2, numBits);
-          numBits++;
-        }
-
-        if (cc < dictionary.length && dictionary.containsKey(cc)) {
-          entry = dictionary[cc];
+      if (cc < dictionary.length && dictionary.containsKey(cc)) {
+        entry = dictionary[cc];
+      } else {
+        if (cc == dictSize) {
+          entry = w + w[0];
         } else {
-          if (cc == dictSize) {
-            entry = w + w[0];
-          } else {
-            return null;
-          }
-        }
-        result.write(entry);
-
-        // Add w+entry[0] to the dictionary.
-        dictionary[dictSize++] = w + entry[0];
-        enLargeIn--;
-
-        w = entry;
-
-        if (enLargeIn == 0) {
-          enLargeIn = pow(2, numBits);
-          numBits++;
+          return null;
         }
       }
-    });
+      result.write(entry);
+
+      // Add w+entry[0] to the dictionary.
+      dictionary[dictSize++] = w + entry[0];
+      enLargeIn--;
+
+      w = entry;
+
+      if (enLargeIn == 0) {
+        enLargeIn = pow(2, numBits);
+        numBits++;
+      }
+    }
   }
 }


### PR DESCRIPTION
To put it simply, given any async function in the lzstring source  file

```dart
/// Documentation
Future<String> someFunction(String param) async {
     return "some result involving $param"
}
```
Was changed to

```dart
/// Documentation
String someFunctionSync(String param) {
     return "some result involving $param"
}

/// Documentation
Future<String> someFunction(String param) async => someFunctionSync(param);
```

The update which made all functions async made it impossible to upgrade (or at least it would take a lot of time to adapt all of my code to support the new "async" functions).

The functions as they are on master literally do the same exact way with this change, it just allows calling them sync. I would really appreciate this getting in so our team can continue using the latest version of lzstring. Thanks!